### PR TITLE
Use `pip` to do the build & install

### DIFF
--- a/conda/recipes/ptxcompiler/meta.yaml
+++ b/conda/recipes/ptxcompiler/meta.yaml
@@ -14,12 +14,12 @@ source:
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
   string: cuda_{{ cuda_version }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
-  script: python setup.py install
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   build:
     - python
-    - setuptools
+    - pip
   run:
     - python
     - numba >=0.54

--- a/conda/recipes/ptxcompiler/meta.yaml
+++ b/conda/recipes/ptxcompiler/meta.yaml
@@ -26,9 +26,11 @@ requirements:
 
 test:
   requires:
+    - pip
     - pytest
 
   commands:
+    - pip check
     - python -c "from ptxcompiler import patch; patch.patch_numba_codegen_if_needed()"
     - pytest -v --pyargs ptxcompiler
 


### PR DESCRIPTION
Should play it bit nicer with `pip` and other Python packaging tools. Also uses a wheel instead of an egg.