### PR TITLE
Leave string length calculation to create's C implementation

### DIFF
--- a/ptxcompiler/_ptxcompilerlib.cpp
+++ b/ptxcompiler/_ptxcompilerlib.cpp
@@ -18,6 +18,7 @@
 #include <Python.h>
 #include <new>
 #include <nvPTXCompiler.h>
+#include <string.h>
 
 static PyObject *get_version(PyObject *self) {
   unsigned int major, minor;
@@ -49,12 +50,11 @@ error:
 }
 
 static PyObject *create(PyObject *self, PyObject *args) {
-  Py_ssize_t ptx_code_len;
   PyObject *ret = nullptr;
   char *ptx_code;
   nvPTXCompilerHandle *compiler;
 
-  if (!PyArg_ParseTuple(args, "ns", &ptx_code_len, &ptx_code))
+  if (!PyArg_ParseTuple(args, "s", &ptx_code))
     return nullptr;
 
   try {
@@ -65,7 +65,7 @@ static PyObject *create(PyObject *self, PyObject *args) {
   }
 
   nvPTXCompileResult res =
-      nvPTXCompilerCreate(compiler, ptx_code_len, ptx_code);
+      nvPTXCompilerCreate(compiler, strlen(ptx_code), ptx_code);
   if (res != NVPTXCOMPILE_SUCCESS) {
     PyErr_SetString(PyExc_RuntimeError, "Error calling nvPTXCompilerCreate");
     goto error;

--- a/ptxcompiler/api.py
+++ b/ptxcompiler/api.py
@@ -24,7 +24,7 @@ PTXCompilerResult = namedtuple(
 
 def compile_ptx(ptx, options):
     options = tuple(options)
-    handle = _ptxcompilerlib.create(len(ptx), ptx)
+    handle = _ptxcompilerlib.create(ptx)
     try:
         _ptxcompilerlib.compile(handle, options)
     except RuntimeError:

--- a/ptxcompiler/tests/test_lib.py
+++ b/ptxcompiler/tests/test_lib.py
@@ -53,24 +53,24 @@ def test_get_version():
 
 
 def test_create():
-    handle = _ptxcompilerlib.create(len(PTX_CODE), PTX_CODE)
+    handle = _ptxcompilerlib.create(PTX_CODE)
     assert handle != 0
 
 
 def test_destroy():
-    handle = _ptxcompilerlib.create(len(PTX_CODE), PTX_CODE)
+    handle = _ptxcompilerlib.create(PTX_CODE)
     _ptxcompilerlib.destroy(handle)
 
 
 def test_compile():
     # Check that compile does not error
-    handle = _ptxcompilerlib.create(len(PTX_CODE), PTX_CODE)
+    handle = _ptxcompilerlib.create(PTX_CODE)
     _ptxcompilerlib.compile(handle, OPTIONS)
 
 
 def test_compile_options():
     options = ('--gpu-name=sm_75', '--device-debug')
-    handle = _ptxcompilerlib.create(len(PTX_CODE), PTX_CODE)
+    handle = _ptxcompilerlib.create(PTX_CODE)
     _ptxcompilerlib.compile(handle, options)
     compiled_program = _ptxcompilerlib.get_compiled_program(handle)
     assert b'nv_debug' in compiled_program
@@ -78,7 +78,7 @@ def test_compile_options():
 
 def test_compile_options_bad_option():
     options = ('--gpu-name=sm_75', '--bad-option')
-    handle = _ptxcompilerlib.create(len(PTX_CODE), PTX_CODE)
+    handle = _ptxcompilerlib.create(PTX_CODE)
     with pytest.raises(RuntimeError):
         _ptxcompilerlib.compile(handle, options)
     error_log = _ptxcompilerlib.get_error_log(handle)
@@ -87,7 +87,7 @@ def test_compile_options_bad_option():
 
 def test_get_error_log():
     bad_ptx = ".target sm_52"
-    handle = _ptxcompilerlib.create(len(bad_ptx), bad_ptx)
+    handle = _ptxcompilerlib.create(bad_ptx)
     with pytest.raises(RuntimeError):
         _ptxcompilerlib.compile(handle, OPTIONS)
 
@@ -96,7 +96,7 @@ def test_get_error_log():
 
 
 def test_get_info_log():
-    handle = _ptxcompilerlib.create(len(PTX_CODE), PTX_CODE)
+    handle = _ptxcompilerlib.create(PTX_CODE)
     _ptxcompilerlib.compile(handle, OPTIONS)
     info_log = _ptxcompilerlib.get_info_log(handle)
     # Info log is empty
@@ -104,7 +104,7 @@ def test_get_info_log():
 
 
 def test_get_compiled_program():
-    handle = _ptxcompilerlib.create(len(PTX_CODE), PTX_CODE)
+    handle = _ptxcompilerlib.create(PTX_CODE)
     _ptxcompilerlib.compile(handle, OPTIONS)
     compiled_program = _ptxcompilerlib.get_compiled_program(handle)
     # Check the compiled program is an ELF file by looking for the ELF header


### PR DESCRIPTION
This simplifies `create` API and make it more "Pythonic".