### PR TITLE
Don't set a new exception when `Py_BuildValue()` returns `null`

### DIFF
--- a/ptxcompiler/_ptxcompilerlib.cpp
+++ b/ptxcompiler/_ptxcompilerlib.cpp
@@ -61,7 +61,6 @@ void set_exception(PyObject *exception_type,
 
 static PyObject *get_version(PyObject *self) {
   unsigned int major, minor;
-  PyObject *py_version = nullptr;
 
   nvPTXCompileResult res = nvPTXCompilerGetVersion(&major, &minor);
   if (res != NVPTXCOMPILE_SUCCESS) {
@@ -71,16 +70,7 @@ static PyObject *get_version(PyObject *self) {
     return nullptr;
   }
 
-  if ((py_version = Py_BuildValue("(II)", major, minor)) == nullptr) {
-    PyErr_SetString(PyExc_RuntimeError, "Error creating tuple");
-    goto error;
-  }
-
-  return py_version;
-
-error:
-  Py_XDECREF(py_version);
-  return nullptr;
+  return Py_BuildValue("(II)", major, minor);
 }
 
 static PyObject *create(PyObject *self, PyObject *args) {


### PR DESCRIPTION
When `Py_BuildValue()` returns `null`, an exception is already set (https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue) - setting another exception would seem to obscure the original cause of the failure.