### PR TITLE
Use subprocess for version check instead of multiprocessing

### DIFF
--- a/ptxcompiler/patch.py
+++ b/ptxcompiler/patch.py
@@ -103,6 +103,8 @@ def print_driver_and_runtime_versions():
 
 
 def patch_needed():
+    logger = get_logger()
+
     cp = subprocess.run([sys.executable, '-c',
                          'from ptxcompiler.patch import '
                          'print_driver_and_runtime_versions; '
@@ -111,14 +113,15 @@ def patch_needed():
 
     if cp.returncode:
         msg = (f'Error getting driver and runtime versions:\n\nstdout:\n\n'
-               f'{cp.stdout.decode()}\n\nstderr:\n\n{cp.stderr.decode()}')
-        raise RuntimeError(msg)
+               f'{cp.stdout.decode()}\n\nstderr:\n\n{cp.stderr.decode()}\n\n'
+               'Not patching Numba')
+        logger.error(msg)
+        return False
 
     versions = [int(s) for s in cp.stdout.strip().split()]
     driver_version = tuple(versions[:2])
     runtime_version = tuple(versions[2:])
 
-    logger = get_logger()
     logger.debug("CUDA Driver version %s.%s" % driver_version)
     logger.debug("CUDA Runtime version %s.%s" % runtime_version)
 


### PR DESCRIPTION
This is not ready yet, as it causes odd behaviour in the Numba test suite - the test suite loops round forever, and strange exceptions are observed, e.g.:

```
test_cudajit_in_attached_primary_context (numba.cuda.tests.cudadrv.test_context_stack.Test3rdPartyContext) ... Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/multiprocessing/spawn.py", line 116, in spawn_main
    exitcode = _main(fd, parent_sentinel)
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/multiprocessing/spawn.py", line 125, in _main
    prepare(preparation_data)
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/multiprocessing/spawn.py", line 236, in prepare
    _fixup_main_from_path(data['init_main_from_path'])
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/multiprocessing/spawn.py", line 287, in _fixup_main_from_path
    main_content = runpy.run_path(main_path,
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/runpy.py", line 268, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/runpy.py", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/gmarkall/numbadev/numba/test.py", line 6, in <module>
    numba.runtests.main('numba.cuda.tests', '-v', '-m')
  File "/home/gmarkall/numbadev/numba/numba/testing/_runtests.py", line 32, in main
    return _main(['<main>'] + list(argv), **kwds)
  File "/home/gmarkall/numbadev/numba/numba/testing/_runtests.py", line 25, in _main
    return run_tests(argv, defaultTest='numba.tests',
  File "/home/gmarkall/numbadev/numba/numba/testing/__init__.py", line 54, in run_tests
    prog = NumbaTestProgram(argv=argv,
  File "/home/gmarkall/numbadev/numba/numba/testing/main.py", line 168, in __init__
    super(NumbaTestProgram, self).__init__(*args, **kwargs)
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/unittest/main.py", line 101, in __init__
    self.runTests()
  File "/home/gmarkall/numbadev/numba/numba/testing/main.py", line 340, in runTests
    run_tests_real()
  File "/home/gmarkall/numbadev/numba/numba/testing/main.py", line 325, in run_tests_real
    super(NumbaTestProgram, self).runTests()
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/unittest/main.py", line 271, in runTests
    self.result = testRunner.run(self.test)
  File "/home/gmarkall/numbadev/numba/numba/testing/main.py", line 795, in run
    return super(ParallelTestRunner, self).run(self._run_inner)
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/unittest/runner.py", line 176, in run
    test(result)
  File "/home/gmarkall/numbadev/numba/numba/testing/main.py", line 761, in _run_inner
    stests.run(result)
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/unittest/suite.py", line 122, in run
    test(result)
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/unittest/case.py", line 653, in __call__
    return self.run(*args, **kwds)
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/unittest/case.py", line 593, in run
    self._callTestMethod(testMethod)
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/unittest/case.py", line 550, in _callTestMethod
    method()
  File "/home/gmarkall/numbadev/numba/numba/cuda/tests/cudadrv/test_managed_alloc.py", line 47, in test_managed_alloc_driver_undersubscribe
    self._test_managed_alloc_driver(0.5)
  File "/home/gmarkall/numbadev/numba/numba/cuda/tests/cudadrv/test_managed_alloc.py", line 92, in _test_managed_alloc_driver
    self.assertTrue(np.all(ary == magic))
KeyboardInterrupt
```

and

```
test_nvvm_path_decision (numba.cuda.tests.nocuda.test_library_lookup.TestNvvmLookUp) ... ERROR

======================================================================
ERROR: test_cudalib_path_decision (numba.cuda.tests.nocuda.test_library_lookup.TestCudaLibLookUp)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/gmarkall/numbadev/numba/numba/cuda/tests/nocuda/test_library_lookup.py", line 40, in setUp
    self.child_process.start()
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/multiprocessing/context.py", line 284, in _Popen
    return Popen(process_obj)
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/multiprocessing/popen_spawn_posix.py", line 32, in __init__
    super().__init__(process_obj)
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/multiprocessing/popen_spawn_posix.py", line 42, in _launch
    prep_data = spawn.get_preparation_data(process_obj._name)
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/multiprocessing/spawn.py", line 154, in get_preparation_data
    _check_not_importing_main()
  File "/home/gmarkall/miniconda3/envs/numbanp120/lib/python3.9/multiprocessing/spawn.py", line 134, in _check_not_importing_main
    raise RuntimeError('''
RuntimeError: 
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.

```

