### PR TITLE
Undo the assumption of driver version 11.4 on WSL2

### DIFF
--- a/ptxcompiler/patch.py
+++ b/ptxcompiler/patch.py
@@ -90,28 +90,13 @@ class PTXStaticCompileCodeLibrary(codegen.CUDACodeLibrary):
         return cubin
 
 
-# Determine the driver and runtime versions for comparison. The logic here is a
-# little odd because the WSL2 preview driver (510.06 at the time of writing)
-# reports a CUDA version of 11.6 but it only accepts PTX up to version 7.4,
-# which is the maximum supported version for 11.4 - see the table in:
-#
-# https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#release-notes)
-#
-# So, for WSL2 we report a driver version of 11.4, because the patch will be
-# needed if we have a toolkit version greater than 11.4.
 CMD = """\
 from ctypes import c_int, byref
 from numba import cuda
-import platform
-
-if 'microsoft-standard-WSL2' in platform.platform():
-    drv_major, drv_minor = 11, 4
-else:
-    dv = c_int(0)
-    cuda.cudadrv.driver.driver.cuDriverGetVersion(byref(dv))
-    drv_major = dv.value // 1000
-    drv_minor = (dv.value - (drv_major * 1000)) // 10
-
+dv = c_int(0)
+cuda.cudadrv.driver.driver.cuDriverGetVersion(byref(dv))
+drv_major = dv.value // 1000
+drv_minor = (dv.value - (drv_major * 1000)) // 10
 run_major, run_minor = cuda.runtime.get_version()
 print(f'{drv_major} {drv_minor} {run_major} {run_minor}')
 """

--- a/ptxcompiler/patch.py
+++ b/ptxcompiler/patch.py
@@ -49,7 +49,8 @@ def get_logger():
         if config.CUDA_LOG_LEVEL:
             # Create a simple handler that prints to stderr
             handler = logging.StreamHandler(sys.stderr)
-            fmt = '== CUDA [%(relativeCreated)d] %(levelname)5s -- %(message)s'
+            fmt = ('== CUDA (ptxcompiler) [%(relativeCreated)d] '
+                   '%(levelname)5s -- %(message)s')
             handler.setFormatter(logging.Formatter(fmt=fmt))
             logger.addHandler(handler)
         else:
@@ -125,8 +126,9 @@ def patch_needed():
 
 
 def patch_numba_codegen_if_needed():
+    logger = get_logger()
     if patch_needed():
-        logger = get_logger()
-        debug_msg = "Patching Numba codegen for forward compatibility"
-        logger.debug(debug_msg)
+        logger.debug("Patching Numba codegen for forward compatibility")
         codegen.JITCUDACodegen._library_class = PTXStaticCompileCodeLibrary
+    else:
+        logger.debug("Driver version sufficient: not patching Numba codegen")


### PR DESCRIPTION
The WSL2 preview driver (which identifies itself as 510.06/ CUDA 11.6) only supported PTX up to version 7.4. However, the latest release driver (496.49) correctly reports the CUDA version it supports (11.5).

Instead of making assumptions about the supported PTX version on WSL based on incorrect behaviour of the preview driver, we should use the reported version as normal, and recommend the use of the latest release driver (and to discontinue use of the preview driver).

This PR also includes some small logging improvements that would have been useful when debugging related issues on WSL2 recently.

After this PR is merged, I think we will need to do another release of ptxcompiler so that WSL2 users don't get the patch erroneously applied.

cc @shwina @taureandyernv @jakirkham 