### PR TITLE
Add missing selector in conda_build_config.yaml file

### DIFF
--- a/conda/recipes/ptxcompiler/conda_build_config.yaml
+++ b/conda/recipes/ptxcompiler/conda_build_config.yaml
@@ -3,4 +3,4 @@ c_compiler_version:       # [linux]
 cxx_compiler_version:     # [linux]
   - 9                     # [linux]
 fortran_compiler_version: # [linux]
-  - 9
+  - 9                     # [linux]


### PR DESCRIPTION
Add missing `# [linux]` selector in `conda_build_config.yaml` file