### PR TITLE
Allow control of patching via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,16 @@ patch_numba_codegen_if_needed()
 This function spawns a new process to check the CUDA Driver and Runtime
 versions, so it can be safely called at any point in a process. It will only
 patch Numba when the Runtime version exceeds the Driver version.
+
+Under certain circumstances (for example running with InfiniBand
+network stacks), spawning a subprocess might not be possible. For
+these cases, the patching behaviour can be controlled using two
+environment variables:
+
+- `PTXCOMPILER_CHECK_NUMBA_CODEGEN_PATCH_NEEDED`: if set to a truthy
+  integer then a subprocess will be spawned to check if patching Numba
+  is necessary. Default value: True (the subprocess check is carried out)
+- `PTXCOMPILER_APPLY_NUMBA_CODEGEN_PATCH`: if it is known that
+  patching is necessary, but spawning a subprocess is not possible,
+  set this to a truthy integer to unconditionally patch Numba. Default
+  value: False (Numba is not unconditionally patched).

--- a/ptxcompiler/patch.py
+++ b/ptxcompiler/patch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import os
 import subprocess
 import sys
 
@@ -127,7 +128,25 @@ def patch_needed():
 
 def patch_numba_codegen_if_needed():
     logger = get_logger()
-    if patch_needed():
+    check = os.getenv("PTXCOMPILER_CHECK_NUMBA_CODEGEN_PATCH_NEEDED")
+    apply = os.getenv("PTXCOMPILER_APPLY_NUMBA_CODEGEN_PATCH")
+    if check is not None:
+        logger.debug(f"PTXCOMPILER_CHECK_NUMBA_CODEGEN_PATCH_NEEDED={check}")
+        try:
+            check = int(check)
+        except ValueError:
+            check = False
+    else:
+        check = True
+    if apply is not None:
+        logger.debug(f"PTXCOMPILER_APPLY_NUMBA_CODEGEN_PATCH={apply}")
+        try:
+            apply = int(apply)
+        except ValueError:
+            apply = False
+    else:
+        apply = False
+    if apply or (check and patch_needed()):
         logger.debug("Patching Numba codegen for forward compatibility")
         codegen.JITCUDACodegen._library_class = PTXStaticCompileCodeLibrary
     else:


### PR DESCRIPTION
Under some circumstances (usually involving InfiniBand network
stacks), fork() has bad consequences. Introduce environment variables
to control the behaviour of patch_numba_codegen_if_needed (which
previously unconditionally forked a subprocess), to both skip the
check and (optionally) unconditionally patch Numba codegen.