### PR TITLE
Remove __cuda metapackage upper bound.

### DIFF
--- a/conda/recipes/ptxcompiler/meta.yaml
+++ b/conda/recipes/ptxcompiler/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - numba >=0.54
     - cudatoolkit >={{ cuda_major ~ ".0" }},<={{ cuda_version }}
   run_constrained:
-    - __cuda >={{ cuda_major ~ ".0" }},<={{ cuda_version }}
+    - __cuda >={{ cuda_major ~ ".0" }}
 
 test:
   requires:


### PR DESCRIPTION
We removed the `__cuda` metapackage upper bound from the conda-forge recipe in https://github.com/conda-forge/ptxcompiler-feedstock/pull/10. This followed from offline discussions with @quasiben, @gmarkall, and others who agreed it was probably a safe decision and would improve forward compatibility as new CUDA releases are available. This PR applies the same change to this repository.