### PR TITLE
Fix making Numba import optional

### DIFF
--- a/ptxcompiler/tests/test_patch.py
+++ b/ptxcompiler/tests/test_patch.py
@@ -17,8 +17,8 @@ import pytest
 
 from ptxcompiler import patch
 from ptxcompiler.patch import (_numba_version_ok,
-                               patch_numba_codegen_if_needed, required_ver,
-                               PTXStaticCompileCodeLibrary)
+                               patch_numba_codegen_if_needed,
+                               required_numba_ver, PTXStaticCompileCodeLibrary)
 from unittest.mock import patch as mock_patch
 
 
@@ -33,7 +33,7 @@ def test_numba_patching_numba_not_ok():
 
 @pytest.mark.skipif(
     not _numba_version_ok,
-    reason=f"Requires Numba >= {required_ver[0]}.{required_ver[1]}"
+    reason=f"Requires Numba >= {required_numba_ver[0]}.{required_numba_ver[1]}"
 )
 def test_numba_patching():
     # We import the codegen here rather than at the top level because the


### PR DESCRIPTION
Changes in #24 turned out to be a step in the right direction but not sufficient to make Numba optional - these additional changes enable the import of ptxcompiler without Numba by adding the following:

- Always defining the required Numba version (needed so that tests can run when Numba is not present)
- Defining `CUDACodeLibrary` when Numba is not present so that the `PTXStaticCompileCodeLibrary` can be defined, though it is not used in this case.
- Immediately returning `False` from `patch_needed()` if Numba is not present, because it cannot be used to check the CUDA version if it is not available.

cc @wence- - apologies for needing this second iteration. I've manually tested this in an environment without Numba too, to make sure that ptxcompiler will import and tests run in that situation.
