### PR TITLE
Create and expose `safe_get_versions()`

### DIFF
--- a/ptxcompiler/patch.py
+++ b/ptxcompiler/patch.py
@@ -150,7 +150,7 @@ def patch_forced_by_user():
         except ValueError:
             apply = False
 
-    return True if apply else False
+    return bool(apply)
 
 
 def check_disabled_in_env():
@@ -167,7 +167,7 @@ def check_disabled_in_env():
     else:
         check = True
 
-    return check == False
+    return not check
 
 
 def patch_needed():

--- a/ptxcompiler/patch.py
+++ b/ptxcompiler/patch.py
@@ -210,6 +210,18 @@ def get_versions():
 
 
 def safe_get_versions():
+    """
+    Return a 2-tuple of deduced driver and runtime versions.
+
+    To ensure that this function does not initialize a CUDA context, calls to the
+    runtime and driver are made in a subprocess.
+
+    If PTXCOMPILER_CHECK_NUMBA_CODEGEN_PATCH_NEEDED is set
+    in the environment, then this subprocess call is not launched. To specify the
+    driver and runtime versions of the environment in this case, set
+    PTXCOMPILER_KNOWN_DRIVER_VERSION and PTXCOMPILER_KNOWN_RUNTIME_VERSION
+    appropriately.
+    """
     if check_disabled_in_env():
         try:
             # allow user to specify driver/runtime versions manually, if necessary

--- a/ptxcompiler/patch.py
+++ b/ptxcompiler/patch.py
@@ -227,7 +227,11 @@ def safe_get_versions():
             # allow user to specify driver/runtime versions manually, if necessary
             driver_version = os.environ["PTXCOMPILER_KNOWN_DRIVER_VERSION"].split(".")
             runtime_version = os.environ["PTXCOMPILER_KNOWN_RUNTIME_VERSION"].split(".")
-        except KeyError:
+            driver_version, runtime_version = (
+                tuple(map(int, driver_version)),
+                tuple(map(int, runtime_version))
+            )
+        except (KeyError, ValueError):
             warnings.warn(
                 "No way to determine driver and runtime versions for patching, "
                 "set PTXCOMPILER_KNOWN_DRIVER_VERSION/PTXCOMPILER_KNOWN_RUNTIME_VERSION"

--- a/ptxcompiler/patch.py
+++ b/ptxcompiler/patch.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import logging
+import math
 import os
 import subprocess
 import sys
+import warnings
 
 from ptxcompiler.api import compile_ptx
 
@@ -26,13 +28,16 @@ required_numba_ver = (0, 54)
 
 try:
     import numba
+
     ver = numba.version_info.short
     if ver >= required_numba_ver:
         _numba_version_ok = True
     else:
-        _numba_error = (f"version {numba.__version__} is insufficient for "
-                        "ptxcompiler patching - at least "
-                        "%s.%s is needed." % required_numba_ver)
+        _numba_error = (
+            f"version {numba.__version__} is insufficient for "
+            "ptxcompiler patching - at least "
+            "%s.%s is needed." % required_numba_ver
+        )
 except ImportError as ie:
     _numba_error = f"failed to import Numba: {ie}."
 
@@ -74,8 +79,10 @@ def get_logger():
         if config.CUDA_LOG_LEVEL:
             # Create a simple handler that prints to stderr
             handler = logging.StreamHandler(sys.stderr)
-            fmt = ('== CUDA (ptxcompiler) [%(relativeCreated)d] '
-                   '%(levelname)5s -- %(message)s')
+            fmt = (
+                "== CUDA (ptxcompiler) [%(relativeCreated)d] "
+                "%(levelname)5s -- %(message)s"
+            )
             handler.setFormatter(logging.Formatter(fmt=fmt))
             logger.addHandler(handler)
         else:
@@ -102,11 +109,11 @@ class PTXStaticCompileCodeLibrary(CUDACodeLibrary):
             msg = "Cannot link multiple PTX files with forward compatibility"
             raise RuntimeError(msg)
 
-        arch = f'sm_{cc[0]}{cc[1]}'
-        options = [f'--gpu-name={arch}']
+        arch = f"sm_{cc[0]}{cc[1]}"
+        options = [f"--gpu-name={arch}"]
 
         if self._max_registers:
-            options.append(f'--maxrregcount={self._max_registers}')
+            options.append(f"--maxrregcount={self._max_registers}")
 
         # Compile PTX to cubin
         ptx = ptxes[0]
@@ -127,15 +134,10 @@ run_major, run_minor = cuda.runtime.get_version()
 print(f'{drv_major} {drv_minor} {run_major} {run_minor}')
 """
 
+logger = get_logger()
 
-def patch_needed():
-    # If Numba is not present, we don't need the patch.
-    # We also can't use it to check driver and runtime versions, so exit early.
-    if not _numba_version_ok:
-        return False
 
-    logger = get_logger()
-
+def patch_forced_by_user():
     # The patch is needed if the user explicitly forced it with an environment
     # variable.
     apply = os.getenv("PTXCOMPILER_APPLY_NUMBA_CODEGEN_PATCH")
@@ -146,9 +148,10 @@ def patch_needed():
         except ValueError:
             apply = False
 
-    if apply:
-        return True
+    return True if apply else False
 
+
+def check_disabled_in_env():
     # We should avoid checking whether the patch is needed if the user
     # requested that we don't check (e.g. in a non-fork-safe environment)
     check = os.getenv("PTXCOMPILER_CHECK_NUMBA_CODEGEN_PATCH_NEEDED")
@@ -161,18 +164,34 @@ def patch_needed():
     else:
         check = True
 
-    if not check:
+    return check == False
+
+
+def patch_needed():
+    # If Numba is not present, we don't need the patch.
+    # We also can't use it to check driver and runtime versions, so exit early.
+    if not _numba_version_ok:
         return False
+    if patch_forced_by_user():
+        return True
+    if check_disabled_in_env():
+        return False
+    else:
+        # Check whether the patch is needed by comparing the driver and runtime
+        # versions - it is needed if the runtime version exceeds the driver
+        # version.
+        driver_version, runtime_version = get_versions()
+        return driver_version < runtime_version
 
-    # Check whether the patch is needed by comparing the driver and runtime
-    # versions - it is needed if the runtime version exceeds the driver
-    # version.
-    cp = subprocess.run([sys.executable, '-c', CMD], capture_output=True)
 
+def get_versions():
+    cp = subprocess.run([sys.executable, "-c", CMD], capture_output=True)
     if cp.returncode:
-        msg = (f'Error getting driver and runtime versions:\n\nstdout:\n\n'
-               f'{cp.stdout.decode()}\n\nstderr:\n\n{cp.stderr.decode()}\n\n'
-               'Not patching Numba')
+        msg = (
+            f"Error getting driver and runtime versions:\n\nstdout:\n\n"
+            f"{cp.stdout.decode()}\n\nstderr:\n\n{cp.stderr.decode()}\n\n"
+            "Not patching Numba"
+        )
         logger.error(msg)
         return False
 
@@ -183,7 +202,24 @@ def patch_needed():
     logger.debug("CUDA Driver version %s.%s" % driver_version)
     logger.debug("CUDA Runtime version %s.%s" % runtime_version)
 
-    return driver_version < runtime_version
+    return driver_version, runtime_version
+
+
+def safe_get_versions():
+    if check_disabled_in_env():
+        try:
+            # allow user to specify driver/runtime versions manually, if necessary
+            driver_version = os.environ["PTXCOMPILER_KNOWN_DRIVER_VERSION"].split(".")
+            runtime_version = os.environ["PTXCOMPILER_KNOWN_RUNTIME_VERSION"].split(".")
+        except KeyError:
+            warnings.warn(
+                "No way to determine driver and runtime versions for patching, "
+                "set PTXCOMPILER_KNOWN_DRIVER_VERSION/PTXCOMPILER_KNOWN_RUNTIME_VERSION"
+            )
+            return math.inf, math.inf
+        else:
+            driver_version, runtime_version = get_versions()
+        return driver_version, runtime_version
 
 
 def patch_numba_codegen_if_needed():

--- a/ptxcompiler/patch.py
+++ b/ptxcompiler/patch.py
@@ -134,10 +134,10 @@ run_major, run_minor = cuda.runtime.get_version()
 print(f'{drv_major} {drv_minor} {run_major} {run_minor}')
 """
 
-logger = get_logger()
 
 
 def patch_forced_by_user():
+    logger = get_logger()
     # The patch is needed if the user explicitly forced it with an environment
     # variable.
     apply = os.getenv("PTXCOMPILER_APPLY_NUMBA_CODEGEN_PATCH")
@@ -152,6 +152,7 @@ def patch_forced_by_user():
 
 
 def check_disabled_in_env():
+    logger = get_logger()
     # We should avoid checking whether the patch is needed if the user
     # requested that we don't check (e.g. in a non-fork-safe environment)
     check = os.getenv("PTXCOMPILER_CHECK_NUMBA_CODEGEN_PATCH_NEEDED")
@@ -185,6 +186,7 @@ def patch_needed():
 
 
 def get_versions():
+    logger = get_logger()
     cp = subprocess.run([sys.executable, "-c", CMD], capture_output=True)
     if cp.returncode:
         msg = (

--- a/ptxcompiler/patch.py
+++ b/ptxcompiler/patch.py
@@ -25,6 +25,8 @@ _numba_version_ok = False
 _numba_error = None
 
 required_numba_ver = (0, 54)
+NO_DRIVER = (math.inf, math.inf)
+
 
 try:
     import numba
@@ -195,7 +197,7 @@ def get_versions():
             "Not patching Numba"
         )
         logger.error(msg)
-        return False
+        return NO_DRIVER
 
     versions = [int(s) for s in cp.stdout.strip().split()]
     driver_version = tuple(versions[:2])
@@ -218,7 +220,7 @@ def safe_get_versions():
                 "No way to determine driver and runtime versions for patching, "
                 "set PTXCOMPILER_KNOWN_DRIVER_VERSION/PTXCOMPILER_KNOWN_RUNTIME_VERSION"
             )
-            return math.inf, math.inf
+            return NO_DRIVER
         else:
             driver_version, runtime_version = get_versions()
         return driver_version, runtime_version


### PR DESCRIPTION
This refactors `patch.py` such that a consumer of `ptxcompiler` can reuse its machinery for safely checking the CUDA driver version. It also introduces two environment variables `PTXCOMPILER_KNOWN_DRIVER_VERSION` and `PTXCOMPILER_KNOWN_RUNTIME_VERSION` that a user can use to hook into the checking logic and disable unsafe forking if necessary. Finally I also ran `black` on this file. 