### PR TITLE
Fix `safe_get_versions` logic

### DIFF
--- a/ptxcompiler/patch.py
+++ b/ptxcompiler/patch.py
@@ -237,9 +237,9 @@ def safe_get_versions():
                 "set PTXCOMPILER_KNOWN_DRIVER_VERSION/PTXCOMPILER_KNOWN_RUNTIME_VERSION"
             )
             return NO_DRIVER
-        else:
-            driver_version, runtime_version = get_versions()
-        return driver_version, runtime_version
+    else:
+        driver_version, runtime_version = get_versions()
+    return driver_version, runtime_version
 
 
 def patch_numba_codegen_if_needed():


### PR DESCRIPTION
Follow up to https://github.com/rapidsai/ptxcompiler/pull/28 fixes a mistake in the logic where nothing was returned if the cuda version checking via subprocess was explicitly disabled. 