### PR TITLE
Prevent patching of Numba 0.57

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ part of the compilation process. This covers all use cases, except:
 
 ## Numba support
 
-Numba 0.54.1 and the current master branch are supported - other versions of
-Numba are unsupported.
+Numba 0.54.1 and above are supported.
 
 
 ## Installation
@@ -49,7 +48,18 @@ python ptxcompiler/tests/test_lib.py
 
 ## Usage
 
-To patch Numba to use the Static PTX Compiler library if needed, call the
+### Numba >= 0.57
+
+To configure Numba to use ptxcompiler, set the environment variable
+`NUMBA_CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY=1`. See the Numba [CUDA Minor
+Version Compatibility
+documentation](https://numba.readthedocs.io/en/stable/cuda/minor_version_compatibility.html)
+for further information.
+
+### Numba versions < 0.57
+
+Numba versions < 0.57 need to be monkey patched to use ptxcompiler if required.
+To apply the monkey patch if needed, call the
 `patch_numba_codegen_if_needed()` function:
 
 ```python

--- a/ptxcompiler/patch.py
+++ b/ptxcompiler/patch.py
@@ -24,22 +24,31 @@ from ptxcompiler.api import compile_ptx
 _numba_version_ok = False
 _numba_error = None
 
-required_numba_ver = (0, 54)
+min_numba_ver = (0, 54)
+max_numba_ver = (0, 56)
 NO_DRIVER = (math.inf, math.inf)
 
+mvc_docs_url = ("https://numba.readthedocs.io/en/stable/cuda/"
+                "minor_version_compatibility.html")
 
 try:
     import numba
 
     ver = numba.version_info.short
-    if ver >= required_numba_ver:
-        _numba_version_ok = True
-    else:
+    if ver < min_numba_ver:
         _numba_error = (
             f"version {numba.__version__} is insufficient for "
             "ptxcompiler patching - at least "
-            "%s.%s is needed." % required_numba_ver
+            "%s.%s is needed." % min_numba_ver
         )
+    elif ver > max_numba_ver:
+        _numba_error = (
+            f"version {numba.__version__} should not be patched. "
+            "Set the environment variable "
+            "NUMBA_CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY=1 instead. "
+            f"See {mvc_docs_url} for more details.")
+    else:
+        _numba_version_ok = True
 except ImportError as ie:
     _numba_error = f"failed to import Numba: {ie}."
 

--- a/ptxcompiler/tests/test_patch.py
+++ b/ptxcompiler/tests/test_patch.py
@@ -18,7 +18,7 @@ import pytest
 from ptxcompiler import patch
 from ptxcompiler.patch import (_numba_version_ok,
                                patch_numba_codegen_if_needed,
-                               required_numba_ver, PTXStaticCompileCodeLibrary)
+                               min_numba_ver, PTXStaticCompileCodeLibrary)
 from unittest.mock import patch as mock_patch
 
 
@@ -33,7 +33,7 @@ def test_numba_patching_numba_not_ok():
 
 @pytest.mark.skipif(
     not _numba_version_ok,
-    reason=f"Requires Numba >= {required_numba_ver[0]}.{required_numba_ver[1]}"
+    reason=f"Requires Numba >= {min_numba_ver[0]}.{min_numba_ver[1]}"
 )
 def test_numba_patching():
     # We import the codegen here rather than at the top level because the


### PR DESCRIPTION
Numba 0.57 should not be patched by ptxcompiler, as its linker already uses ptxcompiler when configured to do so via an environment variable, documented in
https://numba.readthedocs.io/en/stable/cuda/minor_version_compatibility.html.

This prevents ptxcompiler patching these versions of Numba, and advises the use of the environment variable instead.