### PR TITLE
Specify -std=c++11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ module = Extension(
     include_dirs=include_dirs,
     libraries=['nvptxcompiler_static'],
     library_dirs=library_dirs,
-    extra_compile_args=['-Wall', '-Werror'],
+    extra_compile_args=['-Wall', '-Werror', '-std=c++0x'],
 )
 
 if "RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE" in os.environ:

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ module = Extension(
     include_dirs=include_dirs,
     libraries=['nvptxcompiler_static'],
     library_dirs=library_dirs,
-    extra_compile_args=['-Wall', '-Werror', '-std=c++0x'],
+    extra_compile_args=['-Wall', '-Werror', '-std=c++11'],
 )
 
 if "RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE" in os.environ:


### PR DESCRIPTION
For newer compilers the absence of this parameter producing a warning (which is then made into an error by `-Werror`). Specifically, it complains about the usage of nullptr.