### PR TITLE
Add PR build workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,27 @@
+name: pr
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        CUDA_VER: ["11.8.0"]
+    runs-on: ubuntu-latest
+    container: rapidsai/ci:cuda${{ matrix.CUDA_VER }}-ubuntu22.04-py3.10
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: |
+          mamba install -y -c conda-forge boa
+      - name: Run build
+        run: conda mambabuild conda/recipes/ptxcompiler
+        env:
+          CUDA_VER: ${{ matrix.CUDA_VER }}

--- a/conda/recipes/ptxcompiler/conda_build_config.yaml
+++ b/conda/recipes/ptxcompiler/conda_build_config.yaml
@@ -4,3 +4,5 @@ cxx_compiler_version:     # [linux]
   - 9                     # [linux]
 fortran_compiler_version: # [linux]
   - 9                     # [linux]
+cuda_compiler:
+  - nvcc

--- a/conda/recipes/ptxcompiler/meta.yaml
+++ b/conda/recipes/ptxcompiler/meta.yaml
@@ -1,9 +1,9 @@
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set py_version=environ.get('CONDA_PY', 38) %}
-{% set cuda_version='.'.join(environ.get('CUDA', '11.5').split('.')[:2]) %}
-{% set cuda_major=cuda_version.split('.')[0] %}
+{% set cuda_major_minor = ".".join(environ['CUDA_VER'].split(".")[:2]) %}
+{% set cuda_major = cuda_major_minor.split(".")[0] %}
 
 package:
   name: ptxcompiler
@@ -14,6 +14,8 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
+  ignore_run_exports_from:
+    - {{ compiler("cuda") }}
   string: cuda_{{ cuda_major }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -21,14 +23,15 @@ requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
+    - {{ compiler("cuda") }}
   host:
     - python
     - pip
-    - cudatoolkit {{ cuda_version }}.*
+    - cudatoolkit {{ cuda_major_minor }}
   run:
     - python
     - numba >=0.54
-    - cudatoolkit >={{ cuda_major ~ ".0" }},<={{ cuda_version }}
+    - cudatoolkit >={{ cuda_major ~ ".0" }},<={{ cuda_major_minor }}
   run_constrained:
     - __cuda >={{ cuda_major ~ ".0" }}
 


### PR DESCRIPTION
This PR adds a workflow to build `ptxcompiler` for PRs.

This package is uploaded exclusively to `conda-forge` via https://github.com/conda-forge/ptxcompiler-feedstock/.

Therefore there are no other workflows included besides a PR workflow to ensure that any proposed changes continue to build correctly.