### PR TITLE
Don't rely on the Numba version to be OK for config

### DIFF
--- a/conda/recipes/ptxcompiler/meta.yaml
+++ b/conda/recipes/ptxcompiler/meta.yaml
@@ -42,7 +42,6 @@ test:
 
   commands:
     - pip check
-    - python -c "from ptxcompiler import patch; patch.patch_numba_codegen_if_needed()"
     - pytest -v --pyargs ptxcompiler
 
 about:

--- a/ptxcompiler/patch.py
+++ b/ptxcompiler/patch.py
@@ -53,7 +53,6 @@ except ImportError as ie:
     _numba_error = f"failed to import Numba: {ie}."
 
 if _numba_version_ok:
-    from numba import config
     from numba.cuda import codegen
     from numba.cuda.codegen import CUDACodeLibrary
     from numba.cuda.cudadrv import devices
@@ -78,7 +77,7 @@ def get_logger():
 
     # Create a default configuration if none exists already
     if not logger.hasHandlers():
-        lvl = str(config.CUDA_LOG_LEVEL).upper()
+        lvl = str(numba.config.CUDA_LOG_LEVEL).upper()
         lvl = getattr(logging, lvl, None)
 
         if not isinstance(lvl, int):
@@ -87,7 +86,7 @@ def get_logger():
         logger.setLevel(lvl)
 
         # Did user specify a level?
-        if config.CUDA_LOG_LEVEL:
+        if numba.config.CUDA_LOG_LEVEL:
             # Create a simple handler that prints to stderr
             handler = logging.StreamHandler(sys.stderr)
             fmt = (


### PR DESCRIPTION
We still need the Numba config module even if the Numba version is not OK, so we access it directly from the top-level numba module instead of relying on it being imported following from the version being OK.

This should fix the following exception raised when checking whether to patch and the imported Numba version is 0.57:

```
tests/conftest.py:13: in <module>
    import cudf
/opt/conda/envs/test/lib/python3.9/site-packages/cudf/__init__.py:90: in <module>
    _setup_numba()
/opt/conda/envs/test/lib/python3.9/site-packages/cudf/utils/_numba.py:123: in _setup_numba
    versions = safe_get_versions()
/opt/conda/envs/test/lib/python3.9/site-packages/ptxcompiler/patch.py:234: in safe_get_versions
    if check_disabled_in_env():
/opt/conda/envs/test/lib/python3.9/site-packages/ptxcompiler/patch.py:166: in check_disabled_in_env
    logger = get_logger()
/opt/conda/envs/test/lib/python3.9/site-packages/ptxcompiler/patch.py:81: in get_logger
    lvl = str(config.CUDA_LOG_LEVEL).upper()
E   NameError: name 'config' is not defined
```