### PR TITLE
Replace `conda-mambabuild` with `conda-build`

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,11 +18,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install dependencies
-        run: |
-          mamba install -y -c conda-forge boa
       - name: Run build
-        run: conda mambabuild conda/recipes/ptxcompiler
+        run: conda build conda/recipes/ptxcompiler
         env:
           CUDA_VER: ${{ matrix.CUDA_VER }}
   # The following job exists so that it can be set as a consistent required job


### PR DESCRIPTION
These are now equivalent in behavior. However support for `conda-mambabuild` is being dropped. So switch to `conda-build`.

xref: https://github.com/rapidsai/build-planning/issues/149